### PR TITLE
Updated SCEE.cs

### DIFF
--- a/SCEE.cs
+++ b/SCEE.cs
@@ -67,7 +67,7 @@ namespace scee
             rand.NextBytes(nonce);
 
             // Create the cipher instance and initialize.
-            GcmBlockCipher cipher = new GcmBlockCipher(new AesFastEngine());
+            GcmBlockCipher cipher = new GcmBlockCipher(new AesEngine());
             KeyParameter keyParam = ParameterUtilities.CreateKeyParameter(ALGORITHM_NAME, key);
             ParametersWithIV cipherParameters = new ParametersWithIV(keyParam, nonce);
             cipher.Init(true, cipherParameters);
@@ -93,7 +93,7 @@ namespace scee
             Array.Copy(ciphertextAndNonce, nonce.Length, ciphertext, 0, ciphertext.Length);
 
             // Create the cipher instance and initialize.
-            GcmBlockCipher cipher = new GcmBlockCipher(new AesFastEngine());
+            GcmBlockCipher cipher = new GcmBlockCipher(new AesEngine());
             KeyParameter keyParam = ParameterUtilities.CreateKeyParameter(ALGORITHM_NAME, key);
             ParametersWithIV cipherParameters = new ParametersWithIV(keyParam, nonce);
             cipher.Init(false, cipherParameters);


### PR DESCRIPTION
AesFastEngine becomes AesEngine

[https://www.bouncycastle.org/releasenotes.html](https://www.bouncycastle.org/releasenotes.html)
> CVE-2016-1000339: AESFastEngine has a side channel leak if table accesses can be observed. The use of lookup large static lookup tables in AESFastEngine means that where data accesses by the CPU can be observed, it is possible to gain information about the key used to initialize the cipher. We now recommend not using AESFastEngine where this might be a concern. The BC provider is now using AESEngine by default.